### PR TITLE
Support GHC 9.10

### DIFF
--- a/defun-bool/defun-bool.cabal
+++ b/defun-bool/defun-bool.cabal
@@ -43,7 +43,7 @@ library
   hs-source-dirs:    src
   exposed-modules:   SBool.DeFun
   build-depends:
-    , base            ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0
+    , base            ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20.0.0
     , defun-core      ^>=0.1
     , singleton-bool  ^>=0.1.7
 

--- a/defun-core/defun-core.cabal
+++ b/defun-core/defun-core.cabal
@@ -59,7 +59,7 @@ library
     DeFun.List
 
   build-depends:
-    , base            ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0
+    , base            ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20.0.0
 
   x-docspec-extra-packages: defun singleton-bool sop-core
   x-docspec-options:        -XDataKinds -XGADTs -XStandaloneDeriving

--- a/defun-sop/defun-sop.cabal
+++ b/defun-sop/defun-sop.cabal
@@ -43,7 +43,7 @@ library
   hs-source-dirs:    src
   exposed-modules:   Data.SOP.NP.DeFun
   build-depends:
-    , base        ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0
+    , base        ^>=4.16.3.0 || ^>=4.17.2.0 || ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20.0.0
     , defun-core  ^>=0.1
     , sop-core    ^>=0.5.0.2
 


### PR DESCRIPTION
defun builds fine on GHC 9.10 with updated base bounds. I also jailbroke it for a package I wrote that depends on it, and it seems to be fine (testing currently).